### PR TITLE
CentOS bug fix

### DIFF
--- a/butter
+++ b/butter
@@ -6,6 +6,9 @@ use File::Basename;
 my $version_num = "0.3.3"; 
 my $help_message = get_help($version_num);
 
+# Moran Neuhof (neuhofmo) added on 12.9.2016: 
+# In this version I replaced 2> with >& to work on CentOS 6.6
+
 my $version;
 my $help;
 my $quiet;
@@ -483,13 +486,13 @@ if(($bam2wig ne "none") and ($bam2wig_check)) {
     print STDERR "\nCreating wiggle and possible bigwig file\(s\) with bam2wig\n";
     print STDERR "\nAppending bam2wig log information to bam2wig_log.txt\n";
     if($bam2wig eq "combined") {
-	system "bam2wig $final_bam 2>> bam2wig_log.txt";
+	system "bam2wig $final_bam >>& bam2wig_log.txt";
     } elsif ($bam2wig eq "degradome") {
-	system "bam2wig -s top -d $final_bam 2>> bam2wig_log.txt";
-	system "bam2wig -s bottom -d $final_bam 2>> bam2wig_log.txt";
+	system "bam2wig -s top -d $final_bam >>& bam2wig_log.txt";
+	system "bam2wig -s bottom -d $final_bam >>& bam2wig_log.txt";
     } elsif ($bam2wig eq "strandspec2") {
-	system "bam2wig -s top $final_bam 2>> bam2wig_log.txt";
-	system "bam2wig -s bottom $final_bam 2>> bam2wig_log.txt";
+	system "bam2wig -s top $final_bam >>& bam2wig_log.txt";
+	system "bam2wig -s bottom $final_bam >>& bam2wig_log.txt";
     }
 }
 
@@ -708,11 +711,11 @@ sub call_bowtie_iterative {
     # open output streams
     my $out_base = "$$base" . "$$max" . "_placed_sorted";
     my $m_out_base = "$$base" . "_exceeds$$max";
-    (open(BAM, "| samtools view -S -b -u - 2> /dev/null | samtools sort - $out_base 2> /dev/null")) || return 0;
-    (open(MBAM, "| samtools view -S -b -u - 2> /dev/null | samtools sort - $m_out_base 2> /dev/null")) || return 0;
+    (open(BAM, "| samtools view -S -b -u - >& /dev/null | samtools sort - $out_base >& /dev/null")) || return 0;
+    (open(MBAM, "| samtools view -S -b -u - >& /dev/null | samtools sort - $m_out_base >& /dev/null")) || return 0;
 
     # open bowtie process
-    (open(BOWTIE, "$bowtie_call 2> /dev/null |")) || return 0;
+    (open(BOWTIE, "$bowtie_call >& /dev/null |")) || return 0;
     
     # begin parsing
     my $last_read = "NULL";
@@ -1128,9 +1131,9 @@ sub call_bowtie_initial {
     
     # open output streams
     my $unmapped = "$orig_base" . "_unmapped_sorted";
-    (open(UNMAPPED, "| samtools view -S -b -u - 2> /dev/null | samtools sort - $unmapped 2> /dev/null")) || return 0;
+    (open(UNMAPPED, "| samtools view -S -b -u - >& /dev/null | samtools sort - $unmapped >& /dev/null")) || return 0;
     my $unique_bam_prefix = "$orig_base" . "_unique_sorted";
-    (open(UNIQUE, "| samtools view -S -b -u - 2> /dev/null | samtools sort - $unique_bam_prefix 2> /dev/null")) || return 0;
+    (open(UNIQUE, "| samtools view -S -b -u - >& /dev/null | samtools sort - $unique_bam_prefix >& /dev/null")) || return 0;
     
     # Counters
     my $unmap_nr = 0;
@@ -1143,7 +1146,7 @@ sub call_bowtie_initial {
     my $query_n = 0;
     
     # open bowtie stream
-    (open(BOWTIE, "$bowtie_call 2> /dev/null |")) || return 0;
+    (open(BOWTIE, "$bowtie_call >& /dev/null |")) || return 0;
     
     # parse
     my $last_read = "NULL";


### PR DESCRIPTION
Hi,
I realized butter doesn't work for me on one of my two servers, while working fine on the other.
The difference was getting a "Broken pipe" error, which is typical to Linux but not to Perl, so I assumed there was some difference in the OS versions. 
It seems like it worked fine on CentOS 6.3 but not on CentOS 6.6, and I think the problem was the output redirection. While butter runs shell commands with `2>`, my distribution prefers `>&`, so the program just didn't work.
I simply changed the redirection and now it works:
`cat butter | sed 's/2>>/>>\&/g' | sed 's/2>/>\&/g' > butter.modified`

I don't know if this version still works with the rest of the linux distributions but I hope it could solve issues for some users. Probably worth testing or maybe offer this patch for those who encounter problems.

Good luck,
Moran
